### PR TITLE
fixes sorting of migrations

### DIFF
--- a/tortoise_data_migration/__init__.py
+++ b/tortoise_data_migration/__init__.py
@@ -50,7 +50,7 @@ def get_available_migrations(base_package: str) -> typing.List[Migration]:
         migration = Migration(name=match.group(1), package=base_package)
         migrations.append(migration)
         logger.debug(f"Found migration {migration.module_name}")
-    return migrations
+    return sorted(migrations, key=lambda m: m.module_name) 
 
 
 async def get_pending_migrations(base_package: str) -> typing.List[Migration]:


### PR DESCRIPTION
migrations should be executed sorted by filename, i.e:
migration 001_first_migration should be executed before 002_second_migration